### PR TITLE
Fix PHP 8.1+ nullable parameter deprecation warning

### DIFF
--- a/src/Traits/Priceable.php
+++ b/src/Traits/Priceable.php
@@ -208,7 +208,7 @@ trait Priceable
         return $builder->currentlyActive();
     }
 
-    public function prices(PriceType $type = null)
+    public function prices(?PriceType $type = null)
     {
         return $this->morphMany(config('priceable.models.price'), 'priceable');
     }


### PR DESCRIPTION
## Summary
This PR fixes the PHP 8.1+ deprecation warning for implicitly nullable parameters in the `prices()` method.

## Changes
- Updated the `prices()` method in `src/Traits/Priceable.php` to explicitly mark the `$type` parameter as nullable using `?PriceType` syntax
- This prevents the deprecation warning: "Implicitly marking parameter as nullable is deprecated"

## Issue
Fixes #35

## Testing
The change is a simple type declaration update that maintains backward compatibility. No new tests were added as there were no existing tests for this specific method.