### PR TITLE
Fix PHP 8.4 deprecation issues (#38)

### DIFF
--- a/database/migrations/2020_04_02_000007_add_currency_symbol.php
+++ b/database/migrations/2020_04_02_000007_add_currency_symbol.php
@@ -16,7 +16,7 @@ class AddCurrencySymbol extends Migration
     public function up()
     {
         Schema::table('currencies', function (Blueprint $table) {
-            $table->text('symbol', 10)->nullable()->default(NULL)->after('iso_4217');
+            $table->string('symbol', 10)->nullable()->default(NULL)->after('iso_4217');
         });
     }
 

--- a/src/Models/Price.php
+++ b/src/Models/Price.php
@@ -48,7 +48,7 @@ class Price extends Model
     /**
      * This will make sure that the submitted amount in Nova
      * is multiplied by 100 so we can store it in cents.
-     * @param [type] $amount [description]
+     * @param float $amount The amount to be stored in cents
      */
     protected function setDisplayPriceAttribute(float $amount)
     {

--- a/src/Price.php
+++ b/src/Price.php
@@ -64,7 +64,7 @@ class Price
         return $moneyFormatter->format($money);
     }
 
-    public function getMoney($amount, Currency $currency = null)
+    public function getMoney($amount, ?Currency $currency = null)
     {
         if (!$currency) {
             $currency = new Currency('eur');
@@ -78,7 +78,7 @@ class Price
         return request()->getUserLocale();
     }
 
-    public function getCurrency(Currency $currency = null)
+    public function getCurrency(?Currency $currency = null)
     {
         if ($currency) {
             return $currency;

--- a/src/Seeders/CurrencySeeder.php
+++ b/src/Seeders/CurrencySeeder.php
@@ -23,7 +23,7 @@ class CurrencySeeder extends Seeder
     public function run()
     {
         foreach ($this->default_currencies as $currency => $iso) {
-            if (Currency::where('name', $currency)->get()->first()) {
+            if (Currency::where('name', $currency)->first()) {
                 continue;
             }
 

--- a/src/Seeders/VatRatesSeeder.php
+++ b/src/Seeders/VatRatesSeeder.php
@@ -25,7 +25,7 @@ class VatRatesSeeder extends Seeder
     public function run()
     {
         foreach ($this->default_vat_rates as $rate) {
-            if (VatRate::where('name', $rate[0])->get()->first()) {
+            if (VatRate::where('name', $rate[0])->first()) {
                 continue;
             }
 

--- a/src/Traits/Priceable.php
+++ b/src/Traits/Priceable.php
@@ -142,11 +142,11 @@ trait Priceable
     public function getPriceAttribute()
     {
         $type = $this->getPriceType();
-        if (!$this->price($type)) {
+        if (!$this->prices($type)->first()) {
             return;
         }
 
-        return $this->price($type)->price();
+        return $this->prices($type)->first()->price();
     }
 
     /**


### PR DESCRIPTION
## Summary
Resolves #38

- Fixed `Blueprint::text()` method parameter mismatch in currency migration by using `string()` instead
- Fixed invalid `@param` PHPDoc tag in Price model  
- Fixed implicit nullable parameter deprecation warnings by using explicit `?Type` syntax
- Optimized database queries in seeders by removing redundant `get()` calls before `first()`
- Fixed method invocation parameter mismatch in Priceable trait by using `prices()` method correctly

## Test plan
- [x] Syntax checks passed for all modified files
- [x] All PHP 8.4 deprecation warnings addressed as listed in the issue

🤖 Generated with [Claude Code](https://claude.ai/code)