### PR TITLE
Register Price observer in booted() (Laravel 13)

### DIFF
--- a/src/Models/Price.php
+++ b/src/Models/Price.php
@@ -25,13 +25,18 @@ class Price extends Model
     ];
 
     /**
-     * The "booting" method of the model.
+     * The "booted" method of the model.
+     *
+     * Registering the observer runs in booted() rather than boot() because
+     * Model::observe() instantiates the model (new static). As of Laravel 13
+     * that throws a LogicException when done while the model is still booting.
+     * booted() runs after booting completes, so it is safe.
      *
      * @return void
      */
-    protected static function boot()
+    protected static function booted()
     {
-        parent::boot();
+        parent::booted();
         self::observe(self::getObserver());
     }
 


### PR DESCRIPTION
## Why

On Laravel 13 the `Price` model throws on first boot:

> The [Illuminate\\Database\\Eloquent\\Model::bootIfNotBooted] method may not be called on model [Marshmallow\\Priceable\\Models\\Price] while it is being booted.

`Price::boot()` calls `self::observe(self::getObserver())`, and `Model::observe()` does `new static`. Laravel 13 added a guard that throws when a model is instantiated while still booting.

## Fix

Move the observer registration from `boot()` to `booted()`. `booted()` runs after booting completes (`$booted` is set and `$booting` is cleared), so `new static` is safe there.

Required for Laravel 13. Pairs with marshmallow/helpers#61 (the generic ModelObserver fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)