### PR TITLE
Fix $model->price returning unfiltered price (purchase price on overview)

### DIFF
--- a/src/Traits/Priceable.php
+++ b/src/Traits/Priceable.php
@@ -141,12 +141,12 @@ trait Priceable
      */
     public function getPriceAttribute()
     {
-        $type = $this->getPriceType();
-        if (!$this->prices($type)->first()) {
+        $price = $this->price();
+        if (!$price) {
             return;
         }
 
-        return $this->prices($type)->first()->price();
+        return $price->price();
     }
 
     /**


### PR DESCRIPTION
## Problem

A customer saw the **purchase price** on the ecommerce overview page, but the **correct selling price** once the item was in the cart.

`Priceable::getPriceAttribute()` — the `$model->price` / `price_formatted` accessor — resolved the price through the raw relation:

```php
$type = $this->getPriceType();
if (!$this->prices($type)->first()) { return; }
return $this->prices($type)->first()->price();
```

`prices(?PriceType $type = null)` is a plain `morphMany` that **ignores its `$type` argument** and applies **no filtering** — not price type, not currency, not `currentlyActive()`. So `$model->price` returned the *first price row by id*. For a customer whose purchase price was stored before the selling price, that's the purchase price.

The cart was unaffected because it goes through `currentPrice()` → `price()` → `availablePrices()`, which filters by default price type + currency + active state. Hence overview ≠ cart.

## Cause

Regression from **v3.2.2** (PHP 8.4 deprecation hotfix). It rewrote the accessor from `price($type)` to `prices($type)->first()`. The old `price($type)` call only *looked* type-aware — `price()` takes no argument, so `$type` was discarded and the filtered method ran. The hotfix "cleaned up" the dead argument by routing through `prices()`, silently dropping all filtering.

## Fix

Route the accessor through the same filtered `price()` method the cart uses:

```php
$price = $this->price();
if (!$price) { return; }
return $price->price();
```

Overview and cart now resolve identically.

## Verification

Reproduced in a Laravel 13 app with a product carrying two prices (purchase stored first, selling second):

| | before | after |
|---|---|---|
| `$product->price` (overview) | **5.00 (purchase)** | **10.00 (selling)** |
| `$product->currentPrice()` (cart) | 10.00 | 10.00 |

> Note: targeted `main` rather than `develop` — `develop` is behind `main` and is missing the v3.2.2 Laravel 13 observer fix (it crashes on boot under L13). `develop` should have `main` merged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)